### PR TITLE
Add support for Supplementary files

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -138,7 +138,7 @@ class SupplementaryFileChoiceForm(forms.ModelForm):
         files = core_models.File.objects.filter(
             article_id=self.article.pk,
         ).exclude(
-            supplementaryfile__file__article_id = self.article.pk
+            supplementaryfile__file__article_id = self.article.pk,
         )
         self.fields['file'].queryset = files
 

--- a/templates/typesetting/crossref/crossref_component.xml
+++ b/templates/typesetting/crossref/crossref_component.xml
@@ -17,7 +17,7 @@
                     <titles>
                         <title>{{ supp_file.file.label }}</title>
                     </titles>
-                    <format mime_type="{{ supp_file.mime_type }}"/>
+                    <format mime_type="{{ supp_file.file.mime_type }}"/>
                     <doi_data>
                         <doi>{{ doi }}</doi>
                         <resource>{{ supp_file.url }}</resource>

--- a/templates/typesetting/elements/choose_supp_file.html
+++ b/templates/typesetting/elements/choose_supp_file.html
@@ -1,0 +1,30 @@
+{% load foundation %}
+<div class="reveal" id="choose-suppfile" data-reveal data-animation-in="slide-in-up"
+     data-animation-out="slide-out-down">
+    <div class="card">
+        <div class="card-divider">
+            <h4><i class="fa fa-upload">&nbsp;</i>Select File as supplementary</h4>
+        </div>
+    </div>
+    <div class="card-section">
+        {% if error %}
+            <div class="alert alert-warning" role="alert">{{ error }}</div>
+        {% endif %}
+        <button class="close-button" data-close aria-label="Close modal" type="button">
+            <span aria-hidden="true">&times;</span>
+        </button>
+
+        <form method="POST">
+            {% csrf_token %}
+            <div class="clearfix">
+                <div>
+                    {{ supp_choice_form|foundation }}
+                    <button type="submit" class="button success float-right" name="choice-supp"><i
+                            class="fa fa-upload">
+                        &nbsp;</i>Submit
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/typesetting/elements/supp_file_doi.html
+++ b/templates/typesetting/elements/supp_file_doi.html
@@ -1,0 +1,25 @@
+<div class="reveal" id="mint_doi_{{supp_file.pk}}" data-reveal data-animation-in="slide-in-up"
+     data-animation-out="slide-out-down">
+    <div class="card">
+        <div class="card-divider">
+            <h4><i class="fa fa-upload">&nbsp;</i>Mint DOI for Supplementary file #{{ supp_file.pk }}: {{ supp_file.label }}</h4>
+        </div>
+    </div>
+    <div class="card-section">
+        <div class="row expanded">
+         {% if supp_file.file.article.get_doi %}
+         <form method="POST" action={% url 'typesetting_mint_supp_doi' supp_file.pk %}>
+            {% csrf_token %}
+            <p class="strong small">Article DOI: {{ supp_file.file.article.get_doi }}</p>
+            <label for="doi">DOI for this supplemetary file</label>
+            <input type="text" name="doi" value="{% if supp_file.doi %}{{ supp_file.doi }}{% else %}{{ supp_file.file.article.get_doi }}.s{{ supp_file.pk }}{% endif %}" required></input>
+            <button class="success button">Mint DOI</button>
+           </form>
+           {% else %}
+           <div class="callout bs-callout-warning">
+             This article doesn't have a DOI. It must have a DOI before you can register a DOI for supplementary files
+           </div>
+           {% endif %}
+        </div>
+    </div>
+</div>

--- a/templates/typesetting/elements/supplementary_files.html
+++ b/templates/typesetting/elements/supplementary_files.html
@@ -1,0 +1,53 @@
+{% load files %}
+{% load securitytags %}
+{% load static from staticfiles %}
+{% load render_string %}
+
+<table class="scroll small">
+    <tr style="text-align: left">
+        <th>ID</th>
+        <th>Label</th>
+        <th width="25%">Filename</th>
+        <th>Modified</th>
+        <th>Download</th>
+        <th>History</th>
+        <th>DOI</th>
+    </tr>
+    {% for supp in article.supplementary_files.all %}
+        {% can_edit_file supp.file supp.article as user_can_edit_file %}
+        <tr>
+            <td>{{ supp.pk }}</td>
+            <td>{{ supp.label }}</td>
+            <td>{{ supp.file.original_filename|truncatechars:40 }}</td>
+            <td>{{ supp.file.date_modified|date:"Y-m-d G:i" }}</td>
+            <td>
+                <a href="{% url 'typesetting_download_file' article.pk supp.file.pk %}"><i
+                        class="fa fa-download">&nbsp;</i></a>
+            </td>
+            <td>
+                {% if user_can_edit_file %}<a href="{% url 'file_history' article.pk supp.file.pk %}?return={{ request.path|urlencode }}"><i
+                        class="fa fa-history">
+                    &nbsp;</i></a>{% endif %}
+            </td>
+            <td>
+                {% if supp.doi %}
+                    {{ supp.doi }}
+                    &nbsp;<a href="{% url 'supp_file_doi' article.pk supp.pk %}"><i
+                        class="fa fa-refresh"></i></a>
+                {% else %}
+                    <a href="{% url 'supp_file_doi' article.pk supp.pk %}">Issue DOI</a>
+                {% endif %}
+            </td>
+        </tr>
+        {% empty %}
+        <tr>
+            <td colspan="10">No supplementary files have been uploaded.</td>
+        </tr>
+    {% endfor %}
+</table>
+
+<div class="float-right"><a class="button success" data-open="suppfile"><i
+        class="fa fa-cloud-upload">
+    &nbsp;</i>Upload a Supplementary File</a>
+</div>
+<br />

--- a/templates/typesetting/elements/supplementary_files.html
+++ b/templates/typesetting/elements/supplementary_files.html
@@ -32,10 +32,10 @@
             <td>
                 {% if supp.doi %}
                     {{ supp.doi }}
-                    &nbsp;<a href="{% url 'supp_file_doi' article.pk supp.pk %}"><i
+                    &nbsp;<a data-open="mint_doi_{{supp.pk}}" article.pk supp.pk %}"><i
                         class="fa fa-refresh"></i></a>
                 {% else %}
-                    <a href="{% url 'supp_file_doi' article.pk supp.pk %}">Issue DOI</a>
+                    <a data-open="mint_doi_{{supp.pk}}" article.pk supp.pk %}">Mint DOI</a>
                 {% endif %}
             </td>
         </tr>

--- a/templates/typesetting/elements/supplementary_files.html
+++ b/templates/typesetting/elements/supplementary_files.html
@@ -46,7 +46,11 @@
     {% endfor %}
 </table>
 
-<div class="float-right"><a class="button success" data-open="suppfile"><i
+<div class="float-right">
+    <a class="button primary" data-open="choose-suppfile"><i
+        class="fa fa-cloud-upload">
+    &nbsp;</i>Choose from article documents</a>
+    <a class="button success" data-open="suppfile"><i
         class="fa fa-cloud-upload">
     &nbsp;</i>Upload a Supplementary File</a>
 </div>

--- a/templates/typesetting/elements/typesetter/supplementary_files.html
+++ b/templates/typesetting/elements/typesetter/supplementary_files.html
@@ -1,0 +1,25 @@
+{% load static from staticfiles %}
+{% load render_string %}
+<table class="scroll small">
+    <tr style="text-align: left">
+        <th>ID</th>
+        <th width="25%">Label</th>
+        <th>DOI</th>
+        <th>Download</th>
+    </tr>
+    {% for supp_file in article.supplementary_files.all %}
+        <tr>
+            <td>{{ supp_file.pk }}</td>
+            <td>{{ supp_file.label|truncatechars:40 }}</td>
+            <td>{{ supp_file.doi }}</td>
+            <td>
+                <a href="{% url 'typesetting_typesetter_download_file' assignment.pk supp_file.file.pk %}"><i
+                        class="fa fa-download">&nbsp;</i></a>
+            </td>
+        {% empty %}
+        <tr>
+            <td colspan="10">No supplementary files have been uploaded.</td>
+        </tr>
+    {% endfor %}
+</table>
+<br />

--- a/templates/typesetting/typesetting_article.html
+++ b/templates/typesetting/typesetting_article.html
@@ -86,6 +86,7 @@
     {% include "typesetting/elements/new_galley.html" %}
     {% include "elements/production/source_files_upload.html" %}
     {% include "elements/production/new_supp_file.html" %}
+    {% include "typesetting/elements/choose_supp_file.html" %}
     {% include "typesetting/elements/new_production_file.html" %}
     {% include "admin/elements/summary_modal.html" %}
     {% for supp_file in article.supplementary_files.all %}

--- a/templates/typesetting/typesetting_article.html
+++ b/templates/typesetting/typesetting_article.html
@@ -49,10 +49,25 @@
                 </p>
                 {% include "typesetting/elements/galleys.html" %}
             </div>
-                <div class="title-area">
-                    <h2>Upload Source Files (optional)</h2>
+        </div>
+        <div class="box">
+            <div class="title-area">
+                <h2>Optional Files</h2>
+            </div>
+          <ul class="accordion" data-accordion data-multi-expand="true" data-allow-all-closed="true" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" id="optional-files">
+            <li class="accordion-item{% if article.supplementary_files.exists %} is-active{% endif %}" data-accordion-item>
+                <a href="#supp-files" class="accordion-title"><h4>Supplementary files</h4></a>
+                <div class="accordion-content" data-tab-content id="supp-files">
+                    <p>
+                        <small>Data files that should be made available to the reader as a download link. You can also register a DOI for these files if you have DOI registration enabled</small>
+                        <small>(HTML/XML figures are always available for download and don't need to be added as supplementary files)</small>
+                    </p>
+                    {% include "typesetting/elements/supplementary_files.html" %}
                 </div>
-                <div class="content">
+            </li>
+            <li class="accordion-item{% if article.source_files.exists %} is-active{% endif %}" data-accordion-item>
+                <a href="#source-files" class="accordion-title"><h4>Source Files</h4></a>
+                <div class="accordion-content" data-tab-content id="source-files">
                     <p><small>
                         Source Files are intermediate files uploaded by the typesetter, that are used to generate the final Typeset files (e.g. Adobe In Design files used to generate the PDF).
                         Uploading these files (where available) is important in case any changes need to be made to the article in the future.
@@ -60,6 +75,7 @@
                     {% include "typesetting/elements/typesetter/source_files.html" %}
 
                 </div>
+            </ul>
         </div>
 
     </div>
@@ -69,6 +85,7 @@
 
     {% include "typesetting/elements/new_galley.html" %}
     {% include "elements/production/source_files_upload.html" %}
+    {% include "elements/production/new_supp_file.html" %}
     {% include "typesetting/elements/new_production_file.html" %}
     {% include "admin/elements/summary_modal.html" %}
 {% endblock body %}

--- a/templates/typesetting/typesetting_article.html
+++ b/templates/typesetting/typesetting_article.html
@@ -88,6 +88,10 @@
     {% include "elements/production/new_supp_file.html" %}
     {% include "typesetting/elements/new_production_file.html" %}
     {% include "admin/elements/summary_modal.html" %}
+    {% for supp_file in article.supplementary_files.all %}
+        {% include "typesetting/elements/supp_file_doi.html" with supp_file=supp_file %}
+    {% endfor %}
+
 {% endblock body %}
 
 

--- a/templates/typesetting/typesetting_assignment.html
+++ b/templates/typesetting/typesetting_assignment.html
@@ -34,6 +34,15 @@
                     <p><small>The following files have been selected for use in generating the typset articles.</small></p>
                     {% include "typesetting/elements/typesetter/files.html" %}
                 </div>
+                {% if article.supplementary_files.exists %}
+                <div class="title-area">
+                    <h2>Supplementary Files</h2>
+                </div>
+                <div class="content">
+                    <p><small>The Editor has uploaded the following Supplementary files</small></p>
+                    {% include "typesetting/elements/typesetter/supplementary_files.html" %}
+                </div>
+                {% endif %}
                 {% if not assignment.cancelled %}
                 <div class="title-area">
                     <h2>Upload Typeset Files</h2>

--- a/urls.py
+++ b/urls.py
@@ -129,4 +129,8 @@ urlpatterns = [
         views.typesetting_delete_galley,
         name='typesetting_delete_galley'
         ),
+    url(r'^supp-file/(?P<supp_file_id>\d+)/doi/$',
+        views.mint_supp_doi,
+        name='typesetting_mint_supp_doi'
+        ),
 ]

--- a/views.py
+++ b/views.py
@@ -128,11 +128,11 @@ def typesetting_article(request, article_id):
         form = forms.SupplementaryFileChoiceForm(request.POST, article=article)
         if form.is_valid():
             supp = form.save()
-        messages.add_message(
-            request,
-            messages.INFO,
-            'Supplementary file created'
-        )
+            messages.add_message(
+                request,
+                messages.INFO,
+                'Supplementary file created',
+            )
         return redirect(
             reverse(
                 'typesetting_article',
@@ -1386,7 +1386,7 @@ def mint_supp_doi(request, supp_file_id):
     )
     # Cope with file not having foreign key to article
     if supp_file.file.article.journal != request.journal:
-        raise Http4()
+        raise Http404()
 
     doi = request.POST.get("doi")
     if not doi:

--- a/views.py
+++ b/views.py
@@ -108,6 +108,16 @@ def typesetting_article(request, article_id):
                 messages.INFO,
                 'Source files uploaded',
             )
+    elif request.POST and 'supp' in request.POST:
+        for uploaded_file in request.FILES.getlist('supp-file'):
+            label = request.POST.get('label', 'Supplementary File')
+            production_logic.save_supp_file(
+                article, request, uploaded_file, label)
+            messages.add_message(
+                request,
+                messages.INFO,
+                'Supplementary file uploaded: %s' % label,
+            )
 
     template = 'typesetting/typesetting_article.html'
     context = {

--- a/views.py
+++ b/views.py
@@ -67,6 +67,7 @@ def typesetting_article(request, article_id):
         article=article,
     )
     manuscript_files = logic.production_ready_files(article)
+    supp_choice_form = forms.SupplementaryFileChoiceForm(article=article)
 
     if not rounds:
         logic.new_typesetting_round(article, rounds, request.user)
@@ -123,6 +124,22 @@ def typesetting_article(request, article_id):
                 'Supplementary file uploaded: %s' % label,
             )
 
+    elif request.POST and 'choice-supp' in request.POST:
+        form = forms.SupplementaryFileChoiceForm(request.POST, article=article)
+        if form.is_valid():
+            supp = form.save()
+        messages.add_message(
+            request,
+            messages.INFO,
+            'Supplementary file created'
+        )
+        return redirect(
+            reverse(
+                'typesetting_article',
+                kwargs={'article_id': article.pk},
+            )
+        )
+
     template = 'typesetting/typesetting_article.html'
     context = {
         'article': article,
@@ -131,6 +148,7 @@ def typesetting_article(request, article_id):
         'manuscript_files': manuscript_files,
         'pending_tasks': logic.typesetting_pending_tasks(rounds[0]),
         'next_element': logic.get_next_element('typesetting_articles', request),
+        'supp_choice_form': supp_choice_form,
     }
 
     return render(request, template, context)


### PR DESCRIPTION
- Adds a form for uploading new supplementary files
- Adds  a form for picking article documents as supplementary files
- Adds a new interface for minting supp file DOIs via modal
- Shows supp files and their DOIs to the typesetter

![supp_files](https://user-images.githubusercontent.com/10760678/115448786-0613bd00-a212-11eb-87e2-18ec722ed5ad.gif)

