### PR TITLE
Allow editing Supplementary file labels

### DIFF
--- a/templates/typesetting/elements/supp_file_label.html
+++ b/templates/typesetting/elements/supp_file_label.html
@@ -1,0 +1,19 @@
+<div class="reveal" id="edit_supp_label_{{supp_file.pk}}" data-reveal data-animation-in="slide-in-up"
+     data-animation-out="slide-out-down">
+    <div class="card">
+        <div class="card-divider">
+            <h4><i class="fa fa-upload">&nbsp;</i>Mint DOI for Supplementary file #{{ supp_file.pk }}: {{ supp_file.label }}</h4>
+        </div>
+    </div>
+    <div class="card-section">
+        <div class="row expanded">
+         <form method="POST" action={% url 'typesetting_article' article.pk %}>
+            {% csrf_token %}
+            <label for="doi">File Label</label>
+            <input type="text" name="edit-label" value="{{ supp_file.label }}" required></input>
+            <input type="hidden" name="supp-id" value="{{ supp_file.pk }}"></input>
+            <button class="success button">Save</button>
+           </form>
+        </div>
+    </div>
+</div>

--- a/templates/typesetting/elements/supplementary_files.html
+++ b/templates/typesetting/elements/supplementary_files.html
@@ -17,12 +17,16 @@
         {% can_edit_file supp.file supp.article as user_can_edit_file %}
         <tr>
             <td>{{ supp.pk }}</td>
-            <td>{{ supp.label }}</td>
+            <td>
+                {{ supp.label }}
+                &nbsp;<a data-open="edit_supp_label_{{supp.pk}}" article.pk supp.pk %}"><i
+                    class="fa fa-edit"></i></a>
+            </td>
             <td>{{ supp.file.original_filename|truncatechars:40 }}</td>
             <td>{{ supp.file.date_modified|date:"Y-m-d G:i" }}</td>
             <td>
                 <a href="{% url 'typesetting_download_file' article.pk supp.file.pk %}"><i
-                        class="fa fa-download">&nbsp;</i></a>
+-                   class="fa fa-download">&nbsp;</i></a>
             </td>
             <td>
                 {% if user_can_edit_file %}<a href="{% url 'file_history' article.pk supp.file.pk %}?return={{ request.path|urlencode }}"><i

--- a/templates/typesetting/typesetting_article.html
+++ b/templates/typesetting/typesetting_article.html
@@ -92,6 +92,7 @@
     {% include "admin/elements/summary_modal.html" %}
     {% for supp_file in article.supplementary_files.all %}
         {% include "typesetting/elements/supp_file_doi.html" with supp_file=supp_file %}
+        {% include "typesetting/elements/supp_file_label.html" with supp_file=supp_file %}
     {% endfor %}
 
 {% endblock body %}

--- a/views.py
+++ b/views.py
@@ -142,6 +142,24 @@ def typesetting_article(request, article_id):
                 kwargs={'article_id': article.pk},
             )
         )
+    elif request.POST and 'edit-label' in request.POST:
+        label = request.POST.get('edit-label', 'Supplementary File')
+        supp_file = get_object_or_404(
+            core_models.SupplementaryFile,
+            id=int(request.POST.get("supp-id", 0)),
+        )
+        file_obj = supp_file.file
+        # Cope with file not having foreign key to article
+        if file_obj.article != article:
+            raise Http404()
+        file_obj.label = label
+        file_obj.save()
+
+        messages.add_message(
+            request,
+            messages.INFO,
+            'Label updated: %s' % label,
+        )
 
     template = 'typesetting/typesetting_article.html'
     context = {
@@ -1476,4 +1494,3 @@ def mint_supp_doi(request, supp_file_id):
             )
 
     return redirect(request.META.get('HTTP_REFERER'))
-


### PR DESCRIPTION
This was only possible via admin before, by editing the underlying file object