### PR TITLE
Test whether proofing metadata matches published metadata

### DIFF
--- a/test_galley.xml
+++ b/test_galley.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.2 20120330//EN" "http://jats.nlm.nih.gov/publishing/1.2/JATS-journalpublishing1.dtd">
+<!--<?xml-stylesheet type="text/xsl" href="article.xsl"?>-->
+<article article-type="research-article" dtd-version="1.2" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="issn">0000-0000</journal-id>
+            <journal-title-group>
+                <journal-title>Journal Title</journal-title>
+            </journal-title-group>
+            <issn pub-type="epub">0000-0000</issn>
+            <publisher>
+                <publisher-name>Publisher Name</publisher-name>
+            </publisher>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="doi">10.1234/test.1234</article-id>
+            <article-categories>
+                <subj-group>
+                    <subject>Subject</subject>
+                </subj-group>
+            </article-categories>
+            <title-group>
+                <article-title>Article Title</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <name>
+                        <surname>Surname</surname>
+                        <given-names>Given Name</given-names>
+                    </name>
+                    <email>email@example.org</email>
+                    <xref ref-type="aff" rid="aff-1">1</xref>
+                </contrib>
+            </contrib-group>
+            <aff id="aff-1"><label>1</label>Organization</aff>
+            <pub-date publication-format="electronic" date-type="pub" iso-8601-date="2023-01-01">
+                <day>01</day>
+                <month>01</month>
+                <year>2023</year>
+            </pub-date>
+            <pub-date pub-type="collection">
+                <year>2023</year>
+            </pub-date>
+            <volume>1</volume>
+            <issue>1</issue>
+            <fpage>1</fpage>
+            <lpage>100</lpage>
+            <permissions>
+                <copyright-statement>Copyright: &#x00A9; 2023 The Author(s)</copyright-statement>
+                <copyright-year>2023</copyright-year>
+                <license license-type="open-access" xlink:href="http://creativecommons.org/licenses/by/4.0/">
+                    <license-p>This is an open-access article distributed under the terms of the Creative Commons Attribution 4.0 International License (CC-BY 4.0), which permits unrestricted use, distribution, and reproduction in any medium, provided the original author and source are credited. See <uri xlink:href="http://creativecommons.org/licenses/by/4.0/">http://creativecommons.org/licenses/by/4.0/</uri>.</license-p>
+                </license>
+            </permissions>
+            <self-uri xlink:href="http://www.example.org/articles/10.1234/test.1234/"/>
+            <abstract>
+                <p>Abstract</p>
+            </abstract>
+        </article-meta>
+    </front>
+    <body>
+        <sec>
+            <title>1 Introduction</title>
+            <p>Introduction</p>
+        </sec>
+        <sec>
+            <title>2 Section Title</title>
+            <p>Para</p>
+        </sec>
+        <sec>
+            <title>7 Conclusion</title>
+            <p>Conclusion</p>
+        </sec>
+    </body>
+    <back>
+    </back>
+</article>

--- a/tests.py
+++ b/tests.py
@@ -285,12 +285,28 @@ class TestTypesetting(TestCase):
         response = self.client.get(url)
         soup = BeautifulSoup(response.content, 'html.parser')
         data = []
-        for included_element in soup.find_all(
-            class_='proofing-test-include'
-        ):
-            for excluded_element in included_element.find_all(
-                class_='proofing-test-exclude'
-            ):
+        include_ids = [
+            'article_opener',
+            'article_metadata',
+            'content',  # This quite generic id in the OLH theme
+                        # predates this proofing test
+            'author_biographies',
+        ]
+        exclude_ids = [
+            'article_how_to_cite',
+            'article_date_published',
+            'note_to_proofreader_1',
+            'note_to_proofreader_2',
+            'article_footer_block',
+        ]
+        for include_id in include_ids:
+            included_element = soup.find(id=include_id)
+            if not included_element:
+                continue
+            for exclude_id in exclude_ids:
+                excluded_element = included_element.find(id=exclude_id)
+                if not excluded_element:
+                    continue
                 excluded_element.decompose()
             data.append(included_element.prettify())
         return data
@@ -299,9 +315,6 @@ class TestTypesetting(TestCase):
         """
         Tests whether the metadata and article text offered
         in proofing matches that of the published article.
-        governed by classes proofing-test-include and
-        proofing-test-exclude applied in the theme template
-        src/themes/OLH/templates/journal/article.html
         """
 
         self.maxDiff = None
@@ -320,9 +333,6 @@ class TestTypesetting(TestCase):
         """
         Tests whether the metadata and article text offered
         in proofing matches that of the published article.
-        governed by classes proofing-test-include and
-        proofing-test-exclude applied in the theme template
-        src/themes/material/templates/journal/article.html
         """
 
         self.maxDiff = None
@@ -341,9 +351,6 @@ class TestTypesetting(TestCase):
         """
         Tests whether the metadata and article text offered
         in proofing matches that of the published article.
-        governed by classes proofing-test-include and
-        proofing-test-exclude applied in the theme template
-        src/themes/clean/templates/journal/article.html
         """
 
         self.maxDiff = None

--- a/views.py
+++ b/views.py
@@ -1328,10 +1328,13 @@ def typesetting_preview_galley(
         template = 'typesetting/preview_embedded.html'
 
     article_content = galley.file_content()
+    galleys = article.galley_set.filter(public=True)
 
     context = {
+        'proofing': True,
         'proofing_task': proofing_task,
         'galley': galley,
+        'galleys': galleys,
         'article': article if article else proofing_task.round.article,
         'identifier_type': 'id',
         'identifier': article.pk if article else proofing_task.round.article.pk,


### PR DESCRIPTION
Fixes #148 

This branch creates a test for each theme that uses BeautifulSoup to compare parts of the HTML response from the `typesetting_preview_galley` url to corresponding parts from the `article_view` url. This is to catch metadata discrepancies that shouldn't be there when someone is trying to predict how the article will look when published.

The corresponding themes in BirkbeckCTP/janeway have been modified in https://github.com/BirkbeckCTP/janeway/pull/3471 with classes `proofing-test-include` and `proofing-test-exclude` to create DOM trees covering the relevant metadata. As a result, these new tests likely won't pass until they are run with the new templates.

I'm not sure what that means for CI testing. Thoughts about how to proceed?